### PR TITLE
guarding against manual edit  overlap in angular 1.2

### DIFF
--- a/angular-minicolors.js
+++ b/angular-minicolors.js
@@ -49,7 +49,11 @@ angular.module('minicolors', [])
       // Watch for changes to the directives options and then call init method again
       scope.$watch(getSettings, initMinicolors, true);
       scope.$watch(attrs.ngModel, function(newValue) {
-        element.minicolors('value', newValue);
+        if(!scope.$$phase) {
+          scope.$apply(function () {
+            element.minicolors('value', newValue);
+          });
+        }
       });
     }
   };


### PR DESCRIPTION
Great and useful directive, it was throwing an exception when using against angularjs 1.2 and I tried to edit the text color value manually. I added a guard and it seems to work fine now.
