### PR TITLE
Correct minicolors destroy

### DIFF
--- a/angular-minicolors.js
+++ b/angular-minicolors.js
@@ -66,7 +66,8 @@ angular.module('minicolors').directive('minicolors', ['minicolors', '$timeout', 
         };
 
         // If we don't destroy the old one it doesn't update properly when the config changes
-        element.minicolors('destroy');
+        if(element.hasClass('minicolors'))
+          element.minicolors('destroy');
 
         // Create the new minicolors widget
         element.minicolors(settings);


### PR DESCRIPTION
If you call minicolors('destroy') on element which was not previously initialized, then parent element is incorrectly removed.

Here is example: http://codepen.io/anon/pen/PwPrZz?editors=101
