### PR TITLE
add support for angular opacity and rgba scope bindings, to work with op...

### DIFF
--- a/angular-minicolors.js
+++ b/angular-minicolors.js
@@ -27,7 +27,7 @@ angular.module('minicolors').provider('minicolors', function () {
 
 });
 
-angular.module('minicolors').directive('minicolors', ['minicolors', '$timeout', function (minicolors, $timeout) {
+angular.module('minicolors').directive('minicolors', ['minicolors', '$timeout', '$parse', function (minicolors, $timeout, $parse) {
   return {
     require: '?ngModel',
     restrict: 'A',
@@ -48,7 +48,9 @@ angular.module('minicolors').directive('minicolors', ['minicolors', '$timeout', 
         //we are in digest or apply, and therefore call a timeout function
         $timeout(function() {
           var color = ngModel.$viewValue;
+          var opacity = scope.$eval(attrs.ngOpacity) || "1.0";
           element.minicolors('value', color);
+          element.minicolors('opacity', opacity);
         }, 0, false);
       };
 
@@ -59,9 +61,16 @@ angular.module('minicolors').directive('minicolors', ['minicolors', '$timeout', 
           return;
         }
         var settings = getSettings();
-        settings.change = function (hex) {
+        settings.change = function (hex, opacity) {
           scope.$apply(function () {
             ngModel.$setViewValue(hex);
+            if (attrs.ngRgba) {
+              var rgba = element.minicolors('rgbaString');
+              $parse(attrs.ngRgba).assign(scope, rgba);
+            }
+            if (attrs.ngOpacity) {
+              $parse(attrs.ngOpacity).assign(scope, opacity);
+            }
           });
         };
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-minicolors",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "homepage": "https://github.com/kaihenzler/angular-minicolors",
   "authors": [
     "Kai Henzler <kai.henzler@gmx.de>"


### PR DESCRIPTION
...acity minicolors picker - bump to 0.0.7


Hi Kai,

this is an update that binds scope variables to the rgba and opacity values that are set when you use minicolors with {opacity:true}.  
in your version 0.0.6, all you can get out of it is the HEX value, now you can get both the rgba(155,155,23,0.5) and the opacity value, or either.

I've also updated the gh-pages branch with a demo if you want to check it out.

Thanks,
Jon