### PR TITLE
Update to fix a bug where the minicolor setting would not update when…

### DIFF
--- a/angular-minicolors.js
+++ b/angular-minicolors.js
@@ -43,14 +43,12 @@ angular.module('minicolors').directive('minicolors', ['minicolors', '$timeout', 
       };
 
       //what to do if the value changed
-      ngModel.$render = function () {
-
+      scope.$watch(function () { return ngModel.$viewValue; }, function (newValue) {
         //we are in digest or apply, and therefore call a timeout function
         $timeout(function() {
-          var color = ngModel.$viewValue;
-          element.minicolors('value', color);
+          element.minicolors('value', newValue);
         }, 0, false);
-      };
+      });
 
       //init method
       var initMinicolors = function () {


### PR DESCRIPTION
… the model referenced an object indirectly (such as the case when one uses value[0], for example, where element 0 can change without value changing.)  In such cases, using  to monitor the value yields the proper behaviour

Basically, using $watch instead results in the proper operation, I'm actually not 100% sure why it doesn't work correctly as-is (though this might be fixed in a future version of Angular - my project uses a rather old version along with ng-grid rather than (the newer) UI-grid.)

It's possible (though I'm not certain) that this could be fixed, instead, by having the function call $setViewValue also (and use the old $render code), to allow it to differentiate between the $viewValue and the $modelValue...
