### PR TITLE
Change dependencies to peerDependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-minicolors",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "homepage": "https://github.com/kaihenzler/angular-minicolors",
   "authors": [
     "Kai Henzler <kai.henzler@gmx.de>"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/kaihenzler/angular-minicolors/issues"
   },
   "homepage": "https://github.com/kaihenzler/angular-minicolors#readme",
-  "dependencies": {
+  "peerDependencies": {
     "jquery-minicolors": "^2.1.10",
     "angular": "^1.4.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-minicolors",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "A wrapper around JQuery MiniColors by Cory LaViska",
   "main": "angular-minicolors.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/kaihenzler/angular-minicolors/issues"
   },
   "homepage": "https://github.com/kaihenzler/angular-minicolors#readme",
-  "dependencies": {
+  "peerDependencies": {
     "jquery-minicolors": "^2.1.10"
   }
 }


### PR DESCRIPTION
dependencies are installed nested in node v4, but installed in parallel in v5.
I think we should install them as "peerDependencies" as we can include them directly using node.js require().