### PR TITLE
angular model variable does not contain the # symbol if the user type the color without it.

### DIFF
--- a/angular-minicolors.js
+++ b/angular-minicolors.js
@@ -80,10 +80,14 @@
           //destroy the old colorpicker if one already exists
           if (element.hasClass('minicolors-input')) {
             element.minicolors('destroy');
+            element.off('blur', onBlur);
           }
 
           // Create the new minicolors widget
           element.minicolors(settings);
+
+          // hook up into the jquery-minicolors onBlur event.
+          element.on('blur', onBlur);
 
           // are we inititalized yet ?
           //needs to be wrapped in $timeout, to prevent $apply / $digest errors
@@ -95,6 +99,13 @@
             }, 0);
             inititalized = true;
             return;
+          }
+
+          function onBlur (e) {
+            scope.$apply(function() {
+                var color = element.minicolors('value');
+                ngModel.$setViewValue(color);
+            });              
           }
         };
 


### PR DESCRIPTION
When using angular-minicolors directive, if a user type a color without the `#` symbol, `jquery-minicolors` will add the `#` to the input control value but the angular model variable is not updated.

Hooking up to the jquery-minicolors onblur event should solve this issue.
